### PR TITLE
Bump swift-sdk to 0.12.0 to fix Swift 6 data-race errors

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "d9b056c6665ce420a4c85a5999e9e9cb6ff92243efea2ef40ae8be4ffb633436",
+  "originHash" : "a433ddaf3244eeb23a5905d8d2a82010993360c2405de6411c63cbcfd82ad977",
   "pins" : [
     {
       "identity" : "eventsource",
@@ -17,15 +17,6 @@
       "state" : {
         "revision" : "c5d11a805e765f52ba34ec7284bd4fcd6ba68615",
         "version" : "1.7.0"
-      }
-    },
-    {
-      "identity" : "swift-async-algorithms",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-async-algorithms.git",
-      "state" : {
-        "revision" : "2971dd5d9f6e0515664b01044826bcea16e59fac",
-        "version" : "1.1.2"
       }
     },
     {
@@ -69,8 +60,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/modelcontextprotocol/swift-sdk.git",
       "state" : {
-        "revision" : "6112a3995a992d159ad0e82c2d62a008ce932666",
-        "version" : "0.11.0"
+        "revision" : "6132fd4b5b4217ce4717c4775e4607f5c3120129",
+        "version" : "0.12.0"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -10,7 +10,7 @@ let package = Package(
     dependencies: [
         .package(url: "https://github.com/apple/swift-argument-parser.git", from: "1.5.0"),
         .package(url: "https://github.com/apple/swift-atomics.git", from: "1.2.0"),
-        .package(url: "https://github.com/modelcontextprotocol/swift-sdk.git", from: "0.11.0"),
+        .package(url: "https://github.com/modelcontextprotocol/swift-sdk.git", from: "0.12.0"),
     ],
     targets: [
         .executableTarget(


### PR DESCRIPTION
## Summary

Building `blew` against Swift 6.3 (`swiftlang-6.3.0.123.5`, Xcode 26) currently fails inside the `swift-sdk` dependency with two `#SendingRisksDataRace` errors in `NetworkTransport.swift`:

```
.build/checkouts/swift-sdk/Sources/MCP/Base/Transports/NetworkTransport.swift:532:33: error:
  sending 'sendContinuationResumed' risks causing data races
.build/checkouts/swift-sdk/Sources/MCP/Base/Transports/NetworkTransport.swift:763:29: error:
  sending 'receiveContinuationResumed' risks causing data races
```

Under strict concurrency, the local ``var …ContinuationResumed: Bool`` is task-isolated, so capturing and mutating it inside a ``Task { @MainActor in … }`` closure is no longer allowed.

swift-sdk 0.12.0 fixes this upstream by wrapping the flag in ``@MainActor final class MainFlag { var flag = false }``, making the state itself main-actor-isolated and no longer something that has to cross isolation domains. Bumping the dependency floor from ``0.11.0`` → ``0.12.0`` is enough to unblock the build.

## Changes

- `Package.swift`: `swift-sdk` dependency ``from: "0.11.0"`` → ``from: "0.12.0"``
- `Package.resolved`: regenerated via `swift package update swift-sdk`

## Test plan

- [x] `swift build` succeeds on Swift 6.3 (`Build complete! (62.12s)`)
- [x] `blew scan`, `blew connect`, `blew gatt tree`, `blew read 2A23` verified working against real BLE peripherals (Daikin Madoka BRC1H)
- [ ] CI green

## Notes

swift-sdk 0.12.0 also deprecates ``CallTool.Result.Content.text(_:metadata:)`` in favor of ``.text(text:annotations:_meta:)``. That surfaces as warnings in `Sources/blew/MCP/MCPServer.swift:136` and `:146` but does not block the build. Happy to fold the migration into this PR or leave it for a follow-up — let me know your preference.

🤖 Generated with [Claude Code](https://claude.com/claude-code)